### PR TITLE
Format the volume for /var/lib/dci-ansible-agent

### DIFF
--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -73,6 +73,20 @@
 - name: prepare the jumpbox
   hosts: jumpbox
   tasks:
+    - name: make a filesystem on /dev/vdb if there's none
+      filesystem:
+        fstype: xfs
+        dev: /dev/vdb
+        force: no
+      become: True
+    - name: restore the dci-ansible-agent home directory
+      mount:
+        path: /var/lib/dci-ansible-agent
+        src: /dev/vdb
+        fstype: xfs
+        opts: noatime
+        state: mounted
+      become: True
     - name: install some extra packages
       package:
         name: '{{ item }}'
@@ -104,20 +118,6 @@
         - dci-ansible-agent
         - httpd
         - patch
-      become: True
-    - name: make a filesystem on /dev/vdb if there's none
-      filesystem:
-        fstype: xfs
-        dev: /dev/vdb
-        force: no
-      become: True
-    - name: restore the dci-ansible-agent home directory
-      mount:
-        path: /var/lib/dci-ansible-agent
-        src: /dev/vdb
-        fstype: xfs
-        opts: noatime
-        state: mounted
       become: True
 
 - name: configure dci-ansible-agent

--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -105,6 +105,12 @@
         - httpd
         - patch
       become: True
+    - name: make a filesystem on /dev/vdb if there's none
+      filesystem:
+        fstype: xfs
+        dev: /dev/vdb
+        force: no
+      become: True
     - name: restore the dci-ansible-agent home directory
       mount:
         path: /var/lib/dci-ansible-agent


### PR DESCRIPTION
When the volume is just created, it has to be formatted before it can be
mounted.